### PR TITLE
fix hasher corner cases

### DIFF
--- a/edmtool/command_dispatcher.py
+++ b/edmtool/command_dispatcher.py
@@ -44,7 +44,7 @@ class CommandDispatcher:
         try:
             client = UploaderClient(args.base_url, args.token)
             cd = CommandHandler(client)
-            
+
             if args.action == "create":
                 cd.create(args)
             elif args.action == "update":

--- a/edmtool/errors.py
+++ b/edmtool/errors.py
@@ -29,5 +29,6 @@ class DifferentCellsInTheRowError(Exception):
 class CellIsEmptyError(Exception):
     pass
 
+
 class BaseUrlIsNotHTTPS(Exception):
     pass

--- a/edmtool/hasher.py
+++ b/edmtool/hasher.py
@@ -23,15 +23,10 @@ class Hasher:
         return hashlib.sha256(data).digest()
 
     def _normalize(self, data: str):
-        return unicodedata.normalize('NFKC', data).encode('utf-32-le')
+        return unicodedata.normalize('NFKC', data)
 
     def _work_corner_cases(self, data: str):
-        # TODO: improve corner cases
-        lowered_data = data.strip().lower()
-        cleaned_data = re.sub(r"[\W_]+|(\s{2,})", " ", lowered_data)
-
-        # cleaned_data = re.sub(r"[^\w'-´\s]", '', lowered_data)
-        # trimmed_data = re.sub(r'\s+', " ", cleaned_data)
+        cleaned_data = re.sub(r"[^\w ́]+|(\s{2,})|_", " ", data.lower())
         return cleaned_data.strip()
 
     def _prepare_words(self, data: str):
@@ -41,7 +36,7 @@ class Hasher:
         length = 0
         for word in words:
             length = length + 1
-            dash_ap_count = word.count('´')
+            dash_ap_count = word.count(' ́')
             if dash_ap_count > 0:
                 length = length + dash_ap_count
 
@@ -51,7 +46,7 @@ class Hasher:
         return base64.b64encode(data).decode()
 
     def encode(self, data: str):
-        len, prepared_str = self._prepare_words(data)
-        norm = self._normalize(prepared_str)
-        hashed = self._hashFn(norm)
+        norm = self._normalize(data)
+        len, prepared_str = self._prepare_words(norm)
+        hashed = self._hashFn(prepared_str.encode('utf-32-le'))
         return str(len) + "|" + self._transform_into_base64(hashed)


### PR DESCRIPTION
For the input
```
first_name
Malani-e
Malani'e
Malani`e
Malani_e
Malani´e
Malani e
Malanie`
Malanie'
Malanie_
Malanie´
Malanie 
Malanie-
```
we should be having

```xml
        <Term>2|Kt5JjRhFkmE=</Term>
        <Term>2|Kt5JjRhFkmE=</Term>
        <Term>2|Kt5JjRhFkmE=</Term>
        <Term>2|Kt5JjRhFkmE=</Term>
        <Term>2|yILM4iRjvOw=</Term> <<<<< this is Malani´e -> lowercased into malani ́e
        <Term>2|Kt5JjRhFkmE=</Term>
        <Term>1|hgGce4EZtUs=</Term>
        <Term>1|hgGce4EZtUs=</Term>
        <Term>1|hgGce4EZtUs=</Term>
        <Term>2|Ngzhonfkvyo=</Term> <<<<< this is Malanie´ -> lowercased into malanie ́
        <Term>1|hgGce4EZtUs=</Term>
        <Term>1|hgGce4EZtUs=</Term>
```

Fix the hasher function.