### PR TITLE
add --allow_empty_cells flag for EDM databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,14 @@ You can also use optional argument to indicate that your EDM DB CSV file delimit
 
 The supported hashing algorithms are `spooky` and `sha256`.
 
+If your EDM DB file contains empty cells (e.g., missing email or phone number), you can use the `--allow_empty_cells` flag to include those rows in the output. Without this flag, rows with empty cells are skipped.
+
+```bash
+edmtool encode --algorithm "sha256" --db_file_path ./path/to/your/file.csv --allow_empty_cells
+```
+
+Empty cells will be hashed but will never produce matches during evaluation. This feature requires Nucleuz SDK v4.600 or later.
+
 ### Create a new Database Entry and upload
 
 Create an new EDM DB entry and upload the associated file. The file has to be hashed prior to creating the database entry.

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ If your EDM DB file contains empty cells (e.g., missing email or phone number), 
 edmtool encode --algorithm "sha256" --db_file_path ./path/to/your/file.csv --allow_empty_cells
 ```
 
-Empty cells will be hashed but will never produce matches during evaluation. This feature requires Nucleuz SDK v4.600 or later.
+Empty cells will be hashed but will never produce matches during evaluation.
 
 ### Create a new Database Entry and upload
 

--- a/edmtool/command_dispatcher.py
+++ b/edmtool/command_dispatcher.py
@@ -37,6 +37,11 @@ class CommandDispatcher:
             "--token", help="Cyberhaven API token. Can be obtained in the Dashboard configuration.")
         self.parser.add_argument(
             "--base_url", help="Base URL of the API (should be your cluster deployment URL).")
+        self.parser.add_argument(
+            "--allow_empty_cells",
+            action="store_true",
+            default=False,
+            help="Allow empty cells in the EDM database. Empty cells will be hashed but will never match during evaluation.")
 
     def capture(self):
         args = self.parser.parse_args()

--- a/edmtool/command_handler.py
+++ b/edmtool/command_handler.py
@@ -21,7 +21,8 @@ class CommandHandler:
             )
 
         h = Hasher(args.algorithm)
-        ft = FileTransformer(h, args.db_file_delimiter)
+        allow_empty_cells = getattr(args, 'allow_empty_cells', False)
+        ft = FileTransformer(h, args.db_file_delimiter, allow_empty_cells=allow_empty_cells)
         logging.info(
             f"Encoding file under path {args.db_file_path}... The delimiter is \"{args.db_file_delimiter}\"."
         )

--- a/edmtool/file_transformer.py
+++ b/edmtool/file_transformer.py
@@ -13,9 +13,10 @@ from edmtool.errors import EncodedFileExistsError
 class FileTransformer:
     _encoded_delimiter = ','
 
-    def __init__(self, hasher: Hasher, delimiter=',') -> None:
+    def __init__(self, hasher: Hasher, delimiter=',', allow_empty_cells=False) -> None:
         self._delimiter = delimiter
         self._hasher = hasher
+        self._allow_empty_cells = allow_empty_cells
 
     def _create_new_file_encoded(self, path: str):
         directory, filename = os.path.split(path)
@@ -76,13 +77,12 @@ class FileTransformer:
                                 skip_row = True
 
                             for i in range(len(cells)):
-                                if cells[i] != '':
+                                if cells[i] != '' or self._allow_empty_cells:
                                     cells[i] = self._hasher.encode(cells[i])
                                 else:
-                                    counter += 1
                                     skipped_rows += 1
                                     logging.info(
-                                        f"The row {counter} is malformed.\nCell {i} in the line {counter} is empty, remove the row or fill the cell with the relevant data. The row {counter} is skipped"
+                                        f"Row {counter} has an empty cell at position {i}. The row is skipped. Use --allow_empty_cells to include rows with empty cells."
                                     )
                                     skip_row = True
 

--- a/edmtool/tests/test_file_transformer.py
+++ b/edmtool/tests/test_file_transformer.py
@@ -1,5 +1,10 @@
+import json
+import os
+import tempfile
 import unittest
+
 from edmtool.hasher import Hasher
+from edmtool.file_transformer import FileTransformer
 
 
 class TestHasher(unittest.TestCase):
@@ -27,6 +32,121 @@ class TestHasher(unittest.TestCase):
     def test_spooky_with_multiple_apostrophes(self):
         h = Hasher('spooky', 131313)
         self.assertEqual(h.encode("M'ary's Jones"), "4|9G/d0UUi2lI=")
+
+
+class TestFileTransformerEmptyCells(unittest.TestCase):
+
+    def _create_csv(self, content):
+        f = tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False)
+        f.write(content)
+        f.close()
+        return f.name
+
+    def _read_encoded(self, csv_path):
+        encoded_path = csv_path.replace('.csv', '_encoded.csv')
+        metadata_path = encoded_path.replace('.csv', '_metadata.json')
+        with open(encoded_path) as f:
+            lines = f.read().strip().split('\n')
+        with open(metadata_path) as f:
+            metadata = json.load(f)
+        return lines, metadata, encoded_path, metadata_path
+
+    def _cleanup(self, *paths):
+        for p in paths:
+            if os.path.exists(p):
+                os.unlink(p)
+
+    def test_empty_cells_skipped_by_default(self):
+        csv_path = self._create_csv(
+            "name,email,zip\n"
+            "Jane,,10002\n"
+            "Alice,alice@acme.com,90210\n"
+        )
+        ft = FileTransformer(Hasher('sha256'))
+        ft.create_encoded_file(csv_path)
+        lines, metadata, enc, meta = self._read_encoded(csv_path)
+
+        data_rows = lines[1:]
+        self.assertEqual(len(data_rows), 1, "Row with empty cell should be skipped")
+        self._cleanup(csv_path, enc, meta)
+
+    def test_empty_cells_allowed_with_flag_sha256(self):
+        csv_path = self._create_csv(
+            "name,email,zip\n"
+            "Jane,,10002\n"
+            "Alice,alice@acme.com,90210\n"
+        )
+        ft = FileTransformer(Hasher('sha256'), allow_empty_cells=True)
+        ft.create_encoded_file(csv_path)
+        lines, metadata, enc, meta = self._read_encoded(csv_path)
+
+        data_rows = lines[1:]
+        self.assertEqual(len(data_rows), 2, "All rows should be kept with allow_empty_cells")
+
+        empty_cell_hash = "0|47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU="
+        cells = data_rows[0].split(',')
+        self.assertEqual(cells[1], empty_cell_hash)
+        self._cleanup(csv_path, enc, meta)
+
+    def test_empty_cells_allowed_with_flag_spooky(self):
+        csv_path = self._create_csv(
+            "name,email,zip\n"
+            "Jane,,10002\n"
+            "Alice,alice@acme.com,90210\n"
+        )
+        ft = FileTransformer(Hasher('spooky'), allow_empty_cells=True)
+        ft.create_encoded_file(csv_path)
+        lines, metadata, enc, meta = self._read_encoded(csv_path)
+
+        data_rows = lines[1:]
+        self.assertEqual(len(data_rows), 2)
+
+        empty_cell_hash = "0|UfIPiOZtXZU="
+        cells = data_rows[0].split(',')
+        self.assertEqual(cells[1], empty_cell_hash)
+        self._cleanup(csv_path, enc, meta)
+
+    def test_all_cells_empty_in_row(self):
+        csv_path = self._create_csv(
+            "name,email\n"
+            ",\n"
+            "Alice,alice@acme.com\n"
+        )
+        ft = FileTransformer(Hasher('sha256'), allow_empty_cells=True)
+        ft.create_encoded_file(csv_path)
+        lines, metadata, enc, meta = self._read_encoded(csv_path)
+
+        data_rows = lines[1:]
+        self.assertEqual(len(data_rows), 2)
+
+        empty_cell_hash = "0|47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU="
+        cells = data_rows[0].split(',')
+        self.assertTrue(all(c == empty_cell_hash for c in cells))
+        self._cleanup(csv_path, enc, meta)
+
+    def test_no_empty_cells_unaffected_by_flag(self):
+        csv_path = self._create_csv(
+            "name,email\n"
+            "Jane,jane@acme.com\n"
+            "Alice,alice@acme.com\n"
+        )
+        ft_default = FileTransformer(Hasher('sha256'))
+        ft_default.create_encoded_file(csv_path)
+        lines_default, _, enc, meta = self._read_encoded(csv_path)
+        self._cleanup(enc, meta)
+        os.unlink(csv_path)
+
+        csv_path = self._create_csv(
+            "name,email\n"
+            "Jane,jane@acme.com\n"
+            "Alice,alice@acme.com\n"
+        )
+        ft_flag = FileTransformer(Hasher('sha256'), allow_empty_cells=True)
+        ft_flag.create_encoded_file(csv_path)
+        lines_flag, _, enc, meta = self._read_encoded(csv_path)
+
+        self.assertEqual(lines_default, lines_flag, "Flag should not affect CSVs without empty cells")
+        self._cleanup(csv_path, enc, meta)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add opt-in support for empty cells in EDM databases. When the flag is set, empty cells are hashed (producing 0|<hash_of_empty_bytes>) instead of causing the entire row to be skipped. Empty cells will never match during evaluation. 